### PR TITLE
Use different starter template for aggregate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,16 @@ use fluvio_smartstream::{smartstream, Result, Record, RecordData};
 
 #[smartstream(aggregate)]
 pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData> {
-    let mut acc = String::from_utf8(accumulator.as_ref().to_vec())?;
-    let next = std::str::from_utf8(current.value.as_ref())?;
-    acc.push_str(next);
-    Ok(acc.into())
+    // Parse the accumulator and current record as strings
+    let accumulator_string = std::str::from_utf8(accumulator.as_ref())?;
+    let current_string = std::str::from_utf8(current.value.as_ref())?;
+
+    // Parse the strings into integers
+    let accumulator_int = accumulator_string.parse::<i32>().unwrap_or(0);
+    let current_int = current_string.parse::<i32>()?;
+
+    // Take the sum of the two integers and return it as a string
+    let sum = accumulator_int + current_int;
+    Ok(sum.to_string().into())
 }
 {% endif %}


### PR DESCRIPTION
I decided that I don't like the concatenation example as a first intro to "aggregates", so I'm using the integer-summing example in the template instead. This will flow better with the docs